### PR TITLE
Removed unused imports (fixed Windows compatibility with os library)

### DIFF
--- a/carat/onsets.py
+++ b/carat/onsets.py
@@ -14,14 +14,11 @@ Onsets detection
 
 """
 
-import csv
-from os import wait
-import numpy as np
-
 from . import util
 from . import features
 
 __all__ = ['detection']
+
 
 def detection(signal, fs=22050, **kwargs):
     """Onset detection from audio signal. 


### PR DESCRIPTION
Tested all notebooks in Windows after the fix and everything runs fine.

The problem was that the os library for Windows is slightly different, and the wait function does not exist. Since it wasn't being used I removed the import, which solved the issue.